### PR TITLE
Update info_laender.qmd

### DIFF
--- a/info_laender.qmd
+++ b/info_laender.qmd
@@ -38,7 +38,6 @@ Das IfBQ stellt Materialien mit Hinweisen und Anregungen zur Nutzung für die Un
 # Hessen
 
 * [Hessische Lehrkräfteakademie](https://lehrkraefteakademie.hessen.de/zentrale-lernstandserhebungen)<br/>
-Die Hessische Lehrkräfteakademie stellt eine Vielzahl an [Arbeitsmaterialien](https://lehrkraefteakademie.hessen.de/zentrale-lernstandserhebungen/faqs-und-arbeitshilfen-fuer-lehrkraefte) zur Umsetzung der Lernstandserhebungen zur Verfügung. Das [Wiesbadener Forum](https://lehrkraefteakademie.hessen.de/Zentrale-Lernstandserhebungen/Schulischer-Austausch) fördert den praxisorientierten Erfahrungsaustausch zum Umgang mit den Ergebnissen der Lernstandserhebungen. Die Universität Kassel bietet zudem Materialien zu Mathematik in Klasse 8 an.
 
 # Mecklenburg-Vorpommern
 


### PR DESCRIPTION
auf Anfrage von SHu vom 29.04.2026: Der Text unter Hessische Lehrkräfteakademie sollte rausgenommen werden, nur der Link sollte bestehen bleiben